### PR TITLE
Feat: ADD create and read quiz and answers for first time

### DIFF
--- a/quizki/src/services/quizService.js
+++ b/quizki/src/services/quizService.js
@@ -1,4 +1,7 @@
 import api from './api';
+//  ini adalah versi better dari yang sebelumnya
+//  update : Dapat membaca Jawaban 1st try 
+// Need upgrade : Data saat re-take saat menjalankan local host dan db untuk kedua kali belum bisa (saat relogin)
 
 // Add a cache for correct answers
 const correctAnswersCache = {};


### PR DESCRIPTION
This pull request introduces significant enhancements to the backend functionality and logging, improves serialization and validation, and adds new endpoints to support quiz re-take functionality. Additionally, it includes minor updates to the frontend `LeaderboardPage.jsx` file.

### Backend Enhancements

#### Logging Improvements
* Added centralized logging setup in `backend/main.py` and `backend/crud.py` to log API actions, errors, and user score updates for better visibility and debugging. [[1]](diffhunk://#diff-2833ba8f04f16b19c511efe9b6d77dfb2431f9d57207a1b0d4d4af0e7e434384R6-R8) [[2]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903L15-R37)

#### Quiz Re-take Functionality
* Introduced `delete_user_answer` and `get_user_answer_for_question` functions in `backend/crud.py` to allow users to reset their answers for specific questions.
* Added new endpoints in `backend/main.py` to reset answers for individual questions (`/my-answers/{question_id}`) and all questions in a quiz (`/quizzes/{quiz_id}/reset-answers`).

#### Serialization and Validation Updates
* Improved serialization for quizzes and questions in `backend/crud.py` to avoid Pydantic-related issues and ensure proper formatting for API responses. [[1]](diffhunk://#diff-2833ba8f04f16b19c511efe9b6d77dfb2431f9d57207a1b0d4d4af0e7e434384L291-R362) [[2]](diffhunk://#diff-2833ba8f04f16b19c511efe9b6d77dfb2431f9d57207a1b0d4d4af0e7e434384L308-R383)
* Updated response validation in `backend/main.py` to use `model_validate` (Pydantic v2) instead of `from_orm`. [[1]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903L109-R126) [[2]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903L138-R153)

### Frontend Updates

#### Leaderboard Page Fix
* Added a minor update to `quizki/src/pages/LeaderboardPage.jsx` to address position-related issues.